### PR TITLE
Add source for event participants as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 CiviCRM extension providing custom behaviors for Contributions:
 
-*  Allows modifying the contribution Source field based on the 'source' query string parameter, if such is provided in the URL for a contribution page.
+*  Allows modifying the contribution and participant Source fields based on the 'source' query string parameter, if such is provided in the URL for a contribution page or event registration page.
 
 The extension is licensed under [GPL-3.0](LICENSE.txt).
 
@@ -13,7 +13,7 @@ The extension is licensed under [GPL-3.0](LICENSE.txt).
 
 ## Usage
 
-For any contribution page, append `&source=X` to the URL. This will cause 'X' to be appended to the resulting contribution Source field value.
+For any contribution page or event registration page, append `&source=X` to the URL. This will cause 'X' to be appended to the resulting contribution or participant(s) Source field value.
 
 ## Credits
 Developed by [Joinery](https://joineryhq.com). Concept and initial sponsorship by [Korlon](https://korlon.com).

--- a/info.xml
+++ b/info.xml
@@ -2,7 +2,7 @@
 <extension key="com.joineryhq.referralsource" type="module">
   <file>referralsource</file>
   <name>Referral Source</name>
-  <description>Custom behaviors for Contributions</description>
+  <description>Add source from URL param for Contributions and Event Participants</description>
   <license>GPL-3.0</license>
   <maintainer>
     <author>Allen Shaw</author>
@@ -20,7 +20,7 @@
   <compatibility>
     <ver>5.45</ver>
   </compatibility>
-  <comments>Allows modifying the contribution Source field based on the 'source' query string parameter, if such is provided in the URL for a contribution page. Concept and initial sponored by Korlon.</comments>
+  <comments>Allows modifying the contribution or participant Source field based on the 'source' query string parameter, if such is provided in the URL for a contribution or event registration page. Concept and initial sponored by Korlon.</comments>
   <classloader>
     <psr4 prefix="Civi\" path="Civi"/>
   </classloader>

--- a/referralsource.php
+++ b/referralsource.php
@@ -36,7 +36,7 @@ function referralsource_civicrm_postProcess($formName, &$form) {
         // Add the source param value to the current source, if we haven't already
         // done so for this form (when running with a payment processor, this hook
         // is fired twice, so we have to keep track of this ourselves.)
-        if(!isset($form->_params['_com.joineryhq.referralsource_processed'])) {
+        if (!isset($form->_params['_com.joineryhq.referralsource_processed'])) {
           $newSource = $lastContribution['values'][0]['contribution_source'] . ' - ' . $value;
           $form->_params['_com.joineryhq.referralsource_processed'] = TRUE;
         }
@@ -46,6 +46,49 @@ function referralsource_civicrm_postProcess($formName, &$form) {
           'id' => $form->_contributionID,
           'source' => $newSource,
         ]);
+
+        break;
+      }
+    }
+  }
+}
+
+/**
+ * Implements hook_civicrm_buildForm().
+ * There are too many different paths to get to the thank you page for event registrations, so better to just add source on thankyou
+ */
+function referralsource_civicrm_buildForm($formName, &$form) {
+  if ($formName === 'CRM_Event_Form_Registration_ThankYou') {
+    $controller = $form->getVar('controller');
+    $params = explode('?', $controller->_entryURL);
+    parse_str(end($params), $parseURL);
+
+    foreach ($parseURL as $key => $value) {
+      $newKey = str_replace('amp;', '', $key);
+
+      if ($newKey === 'source') {
+        // if payment, then we get _participantIDS but if no payment, we only get primary _participantId (even if additionals exist)
+        $participantIds = $form->getVar('_participantIDS');
+        // so get additional participants if not given
+        if (!($participantIds)) {
+          $primaryParticipantId = $form->getVar('_participantId');
+          // The API filters out test participants and won't return them unless you specify IS NOT NULL
+          $additionaParticipants = \Civi\Api4\Participant::get(FALSE)
+            ->addWhere('registered_by_id', '=', $primaryParticipantId)
+            ->addWhere('is_test', 'IS NOT NULL')
+            ->execute()->column('id');
+          $participantIds = array_merge([$form->getVar('_participantId')], $additionaParticipants);
+        }
+
+        $primaryParticipant = \Civi\Api4\Participant::get(FALSE)
+          ->addSelect('source')
+          ->addWhere('id', '=', $participantIds[0])
+          ->execute()->first();
+
+        \Civi\Api4\Participant::update(FALSE)
+          ->addValue('source', $primaryParticipant['source'] . ' - ' . $value)
+          ->addWhere('id', 'IN', $participantIds)
+          ->execute();
 
         break;
       }


### PR DESCRIPTION
Works about the same as the existing code for contribution pages, but using the thank you page form instead as it was a real mess trying to handle all the different ways you can do event registrations (from confirm, direct from register, or direct from additional participant).

Tested in all of the configurations I could think of:
- No payment: single, allow multiple with single and multiple
- With payment: single, allow multiple with single and multiple
- Payment at end: single, allow multiple with single and multiple